### PR TITLE
[Feature] Support unified symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ At the parent folder of `tests`, trigger the tests with `pytest`
 
 ## Known gaps
 - Only supports HMAC API Keys
-- [ccxt unified symbols](https://docs.ccxt.com/#/?id=naming-consistency) is not yet implemented. Market symbols are still following Bullish's naming convention. For example, the BTC/USDC spot market have a symbol of `BTCUSDC`.
 - WebSocket support is not available
 - Only read path functionality is available - such as `fetch_markets` and `fetch_orders`. 
 - Wallet/Custody functionality is not available yet

--- a/src/sample.py
+++ b/src/sample.py
@@ -3,4 +3,4 @@ import pprint
 
 exchange = bullish()
 markets = exchange.load_markets()
-pprint.pprint(markets['BTCUSDC'], compact=True)
+pprint.pprint(markets['BTC/USDC'], compact=True)

--- a/src/tests/test_bullish_create_and_fetch_order.py
+++ b/src/tests/test_bullish_create_and_fetch_order.py
@@ -5,7 +5,7 @@ def test_can_create_and_fetch_order():
     if not exchange.check_required_credentials(error=False):
         print("WARNING. apiKey and secret needs to be set before running this test")
 
-    create_order_response = exchange.create_limit_buy_order("BTCUSDC", 0.1, 123.0)
+    create_order_response = exchange.create_limit_buy_order("BTC/USDC", 0.1, 123.0)
     assert matches_schema(create_order_response, create_order_schema)
     
     order_id = create_order_response['orderId']

--- a/src/tests/test_bullish_fetch_ohlcv.py
+++ b/src/tests/test_bullish_fetch_ohlcv.py
@@ -2,5 +2,5 @@ from tests.exchange import exchange
 from tests.schema_utils import matches_schema, candle_schema
 
 def test_can_fetch_ohlcv():
-    ret = exchange.fetch_ohlcv('BTCUSDC', timeframe='30m')
+    ret = exchange.fetch_ohlcv('BTC/USDC', timeframe='30m')
     assert matches_schema(ret, candle_schema)

--- a/src/tests/test_bullish_fetch_orderbook.py
+++ b/src/tests/test_bullish_fetch_orderbook.py
@@ -2,5 +2,5 @@ from tests.exchange import exchange
 from tests.schema_utils import matches_schema, orderbook_schema
 
 def test_can_fetch_orderbook():
-    ret = exchange.fetch_order_book('BTCUSDC')
+    ret = exchange.fetch_order_book('BTC/USDC')
     assert matches_schema(ret, orderbook_schema)

--- a/src/tests/test_bullish_fetch_orders.py
+++ b/src/tests/test_bullish_fetch_orders.py
@@ -8,7 +8,7 @@ def check_credentials():
         print("WARNING. apiKey and secret needs to be set before running this test")
 
 def test_create_order():
-    create_order_response = exchange.create_limit_buy_order("BTCUSDC", 0.1, 123.0)
+    create_order_response = exchange.create_limit_buy_order("BTC/USDC", 0.1, 123.0)
     assert matches_schema(create_order_response, create_order_schema)
 
 def test_can_fetch_orders():

--- a/src/tests/test_bullish_fetch_positions.py
+++ b/src/tests/test_bullish_fetch_positions.py
@@ -3,7 +3,7 @@ from tests.schema_utils import matches_schema, create_order_schema, order_schema
 
 def test_can_create_perp_position():
     # Note: Trading account needs to support margin for this to work
-    create_order_response = exchange.create_market_buy_order("BTC-USDC-PERP", 0.01)
+    create_order_response = exchange.create_market_buy_order("BTC/USDC:USDC", 0.01)
     assert matches_schema(create_order_response, create_order_schema)
     
     order_id = create_order_response['orderId']
@@ -15,5 +15,5 @@ def test_can_fetch_positions():
     assert matches_schema(ret, positions_schema)
 
 def test_can_fetch_position():
-    ret = exchange.fetch_position('BTC-USDC-PERP')
+    ret = exchange.fetch_position('BTC/USDC:USDC')
     assert matches_schema(ret, position_schema)

--- a/src/tests/test_bullish_fetch_tickers.py
+++ b/src/tests/test_bullish_fetch_tickers.py
@@ -2,5 +2,5 @@ from tests.exchange import exchange
 from tests.schema_utils import matches_schema, tickers_schema
 
 def test_can_fetch_tickers():
-    ret = exchange.fetch_tickers(['BTCUSDC'])
+    ret = exchange.fetch_tickers(['BTC/USDC'])
     assert matches_schema(ret, tickers_schema)

--- a/src/tests/test_bullish_fetch_trades.py
+++ b/src/tests/test_bullish_fetch_trades.py
@@ -2,5 +2,5 @@ from tests.exchange import exchange
 from tests.schema_utils import matches_schema, trades_schema
 
 def test_can_fetch_trades():
-    ret = exchange.fetch_trades(symbol='BTCUSDC')
+    ret = exchange.fetch_trades(symbol='BTC/USDC')
     assert matches_schema(ret, trades_schema)


### PR DESCRIPTION
Regression tests passed (after switching to unified symbols)

```
tests/test_bullish_create_and_fetch_order.py .  [  7%]
tests/test_bullish_fetch_currencies.py . [ 14%]
tests/test_bullish_fetch_markets.py . [ 21%]
tests/test_bullish_fetch_ohlcv.py . [ 28%]
tests/test_bullish_fetch_orderbook.py . [ 35%]
tests/test_bullish_fetch_orders.py .... [ 64%]
tests/test_bullish_fetch_positions.py ...  [ 85%]
tests/test_bullish_fetch_tickers.py .  [ 92%]
tests/test_bullish_fetch_trades.py .  [100%]
```